### PR TITLE
Ensure optimal strategy uses consumption data

### DIFF
--- a/ess/simulator.py
+++ b/ess/simulator.py
@@ -115,13 +115,23 @@ class EnergyArbitrageSimulator:
             final_price = price_with_margin * (1 + vat_rate)
             
             # Get strategy decision
-            action, power_kw = self.strategy.decide_action(
-                current_time,
-                base_price,  # Use base price for decisions
-                consumption_kw,
-                self.battery,
-                prices_df
-            )
+            if isinstance(self.strategy, OptimalArbitrageStrategy):
+                action, power_kw = self.strategy.decide_action(
+                    current_time,
+                    base_price,  # Use base price for decisions
+                    consumption_kw,
+                    self.battery,
+                    prices_df,
+                    consumption_df,
+                )
+            else:
+                action, power_kw = self.strategy.decide_action(
+                    current_time,
+                    base_price,  # Use base price for decisions
+                    consumption_kw,
+                    self.battery,
+                    prices_df,
+                )
             
             # Execute battery action
             battery_charge_kwh = 0

--- a/tests/test_optimal_strategy.py
+++ b/tests/test_optimal_strategy.py
@@ -1,0 +1,38 @@
+import os
+import sys
+from datetime import datetime
+import pandas as pd
+
+# Ensure project root is on sys.path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from ess.battery import Battery
+from ess.simulator import EnergyArbitrageSimulator
+from ess.strategies import OptimalArbitrageStrategy
+
+
+def test_optimal_strategy_generates_schedule():
+    start = datetime(2024, 1, 1)
+    # Two days of 15-minute data for lookahead
+    times = pd.date_range(start, periods=96 * 2, freq="15min")
+
+    # Constant consumption 1 kW (0.25 kWh per step)
+    consumption_df = pd.DataFrame({"kwh": 0.25, "kw": 1.0}, index=times)
+
+    # Price low in first half of each day, high in second half
+    prices = [0.05 if t.hour < 12 else 0.2 for t in times]
+    prices_df = pd.DataFrame({"price_eur_per_kwh": prices}, index=times)
+
+    battery = Battery(capacity_kwh=10, max_charge_kw=5, max_discharge_kw=5)
+    strategy = OptimalArbitrageStrategy()
+    sim = EnergyArbitrageSimulator(battery, strategy)
+
+    # Run for first day (48h lookahead requires two days of data)
+    sim.run(consumption_df, prices_df, start, start)
+
+    # Daily schedule should be computed with non-idle actions
+    schedule = strategy.daily_schedule
+    assert schedule is not None
+    assert len(schedule) == 96 * 2
+    assert schedule["action"].isin(["charge", "discharge"]).any()
+


### PR DESCRIPTION
## Summary
- Pass full consumption profile to `OptimalArbitrageStrategy` so it runs dynamic programming instead of falling back to simple arbitrage
- Add regression test verifying that the optimal strategy generates a non-idle schedule

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5f216ee688322bb8228f061297ab7