### PR TITLE
Add consumption model flag to reuse 2024 profile for any year

### DIFF
--- a/configs/scenario.yaml
+++ b/configs/scenario.yaml
@@ -11,6 +11,7 @@ consumption:
   profile_file: "data/e_redes_perfil_consumo.xlsx"
   profile_column: "BTN A"  # Residential profile
   annual_consumption_kwh: 7000  # More typical residential consumption
+  consumption_model: true  # Use 2024 profile for any simulation year
 
 # Electricity tariff
 tariff:

--- a/run_sim.py
+++ b/run_sim.py
@@ -148,7 +148,8 @@ def main():
         config['consumption']['annual_consumption_kwh'],
         start_date,
         end_date,
-        config['consumption']['profile_column']
+        config['consumption']['profile_column'],
+        consumption_model=config['consumption'].get('consumption_model', False)
     )
     
     # Create battery


### PR DESCRIPTION
## Summary
- add `consumption_model` flag so 2024 profile can represent any year
- shift consumption data to 2024 when flag enabled and map back to requested year
- expose new flag in scenario configuration

## Testing
- `python run_sim.py` (start date 2023, num_days 2)


------
https://chatgpt.com/codex/tasks/task_e_68b6de4c1044832294d77f96460a1ab2