### PR TITLE
Add modular tariff processors and support simple and bi-hourly rates

### DIFF
--- a/ess/tariff.py
+++ b/ess/tariff.py
@@ -1,13 +1,14 @@
-"""
-ess/tariff.py - REFACTORED VERSION with modular invoice components
-"""
+"""Tariff helpers and processors used across the project."""
+
+from datetime import datetime
+from typing import Dict, List, Tuple
 
 import pandas as pd
-from datetime import datetime
 
 
 def _is_summer(date: datetime) -> bool:
     """Approximate check for Portuguese summer season (Apr-Oct)."""
+
     return 4 <= date.month <= 10
 
 
@@ -17,135 +18,451 @@ def _minutes(t) -> int:
 
 def _period_daily(ts: datetime, option: str, season: str) -> str:
     m = _minutes(ts.time())
-    if option == 'bi':
+    if option == "bi":
         if m >= 22 * 60 or m < 8 * 60:
-            return 'vazio'
-        return 'fora_vazio'
-    if option == 'tri':
+            return "vazio"
+        return "fora_vazio"
+    if option == "tri":
         if m >= 22 * 60 or m < 8 * 60:
-            return 'vazio'
-        if season == 'winter':
+            return "vazio"
+        if season == "winter":
             if (8 * 60 + 30) <= m < (10 * 60 + 30) or (18 * 60) <= m < (20 * 60 + 30):
-                return 'ponta'
-            return 'cheias'
-        else:  # summer
-            if (10 * 60 + 30) <= m < (12 * 60) or (19 * 60 + 30) <= m < (21 * 60):
-                return 'ponta'
-            return 'cheias'
-    return 'simples'
+                return "ponta"
+            return "cheias"
+        if (10 * 60 + 30) <= m < (12 * 60) or (19 * 60 + 30) <= m < (21 * 60):
+            return "ponta"
+        return "cheias"
+    return "simples"
 
 
 def _period_weekly(ts: datetime, option: str, season: str) -> str:
     m = _minutes(ts.time())
     wd = ts.weekday()  # Monday=0
-    if option == 'bi':
+    if option == "bi":
         if wd <= 4:  # weekdays
-            return 'vazio' if m < 7 * 60 else 'fora_vazio'
+            return "vazio" if m < 7 * 60 else "fora_vazio"
         if wd == 5:  # Saturday
-            if season == 'winter':
-                if m < 9 * 60 + 30 or 13 * 60 <= m < 18 * 60 + 30 or m >= 22 * 60:
-                    return 'vazio'
-                return 'fora_vazio'
-            else:
-                if m < 9 * 60 or 14 * 60 <= m < 20 * 60 or m >= 22 * 60:
-                    return 'vazio'
-                return 'fora_vazio'
-        return 'vazio'  # Sunday
-    if option == 'tri':
+            if season == "winter":
+                if (
+                    m < 9 * 60 + 30
+                    or 13 * 60 <= m < 18 * 60 + 30
+                    or m >= 22 * 60
+                ):
+                    return "vazio"
+                return "fora_vazio"
+            if (
+                m < 9 * 60
+                or 14 * 60 <= m < 20 * 60
+                or m >= 22 * 60
+            ):
+                return "vazio"
+            return "fora_vazio"
+        return "vazio"  # Sunday
+    if option == "tri":
         if wd <= 4:  # weekdays
             if m < 7 * 60:
-                return 'vazio'
-            if season == 'winter':
+                return "vazio"
+            if season == "winter":
                 if 9 * 60 + 30 <= m < 12 * 60 or 18 * 60 + 30 <= m < 21 * 60:
-                    return 'ponta'
-                return 'cheias'
-            else:
-                if 9 * 60 + 15 <= m < 12 * 60 + 15:
-                    return 'ponta'
-                return 'cheias'
+                    return "ponta"
+                return "cheias"
+            if 9 * 60 + 15 <= m < 12 * 60 + 15:
+                return "ponta"
+            return "cheias"
         if wd == 5:  # Saturday
-            if season == 'winter':
+            if season == "winter":
                 if 9 * 60 + 30 <= m < 13 * 60 or 18 * 60 + 30 <= m < 22 * 60:
-                    return 'cheias'
-                return 'vazio'
-            else:
-                if 9 * 60 <= m < 14 * 60 or 20 * 60 <= m < 22 * 60:
-                    return 'cheias'
-                return 'vazio'
-        return 'vazio'  # Sunday
-    return 'simples'
+                    return "cheias"
+                return "vazio"
+            if 9 * 60 <= m < 14 * 60 or 20 * 60 <= m < 22 * 60:
+                return "cheias"
+            return "vazio"
+        return "vazio"  # Sunday
+    return "simples"
 
 
 def get_tariff_period(ts: datetime, option: str, cycle: str) -> str:
-    season = 'summer' if _is_summer(ts) else 'winter'
-    if cycle == 'daily':
+    season = "summer" if _is_summer(ts) else "winter"
+    if cycle == "daily":
         return _period_daily(ts, option, season)
     return _period_weekly(ts, option, season)
 
 
-def apply_indexed_tariff(prices_df: pd.DataFrame, tariff_cfg: dict) -> pd.DataFrame:
-    """
-    REFACTORED: Apply indexed tariff and return electricity term components WITHOUT VAT.
-    
-    Returns prices_df with additional columns:
-    - tariff_period: Time-of-use period
-    - price_omie_adjusted_eur_kwh: OMIE price * (1 + losses) * k1
-    - k2_eur_kwh: K2 network access component  
-    - tariff_energy_eur_kwh: Time-of-use tariff component
-    - price_electricity_base_eur_kwh: Total electricity term (OMIE_adjusted + K2 + TAR)
-    
-    Note: VAT is NOT applied here - it's handled in the billing engine
-    """
-    idx_cfg = tariff_cfg['indexed']
-    option = idx_cfg['option']
-    cycle = idx_cfg['cycle']
-    k1 = idx_cfg['k1']
-    k2 = idx_cfg['k2_eur_kwh']
-    losses = idx_cfg['losses_pct']
-    rates = idx_cfg['tariff_energy_eur_kwh']
+class TariffProcessor:
+    """Base class for all tariff processors."""
 
-    periods = []
-    omie_adjusted = []
-    k2_list = []
-    tariffs = []
-    electricity_base = []
+    def __init__(self, tariff_cfg: Dict):
+        self.config = tariff_cfg
 
-    for ts, row in prices_df.iterrows():
-        # Get tariff period
-        period = get_tariff_period(ts, option, cycle)
-        periods.append(period)
-        
-        # OMIE adjusted for losses and k1
-        omie_adj = row['price_omie_eur_kwh'] * (1 + losses) * k1
-        omie_adjusted.append(omie_adj)
-        
-        # K2 network access
-        k2_list.append(k2)
-        
-        # Time-of-use tariff
-        if option == 'simples':
-            tar = rates['simples']
-        elif option == 'bi':
-            tar = rates['bi'][period]
-        elif option == 'tri':
-            tar = rates['tri'][period]
-        else:
+    def apply(self, prices_df: pd.DataFrame) -> pd.DataFrame:
+        """Return a dataframe with all mandatory tariff columns populated."""
+
+        raise NotImplementedError
+
+    def compute_daily_fixed_costs(
+        self, contracted_power_kva: float
+    ) -> Tuple[Dict[str, float], Dict[str, float]]:
+        """Return fixed term daily costs and metadata for logging."""
+
+        raise NotImplementedError
+
+    def summary_lines(self) -> List[str]:
+        """Human readable summary lines for console output."""
+
+        return []
+
+
+class IndexedTariffProcessor(TariffProcessor):
+    """Processor for indexed tariffs (OMIE + regulated components)."""
+
+    def __init__(self, tariff_cfg: Dict):
+        super().__init__(tariff_cfg)
+        if "indexed" not in tariff_cfg:
+            raise ValueError("Indexed tariff configuration requires 'indexed' section")
+        self.idx_cfg = tariff_cfg["indexed"]
+
+    def apply(self, prices_df: pd.DataFrame) -> pd.DataFrame:
+        df = prices_df.copy()
+
+        option = self.idx_cfg.get("option", "simples")
+        cycle = self.idx_cfg.get("cycle", "daily")
+        k1 = float(self.idx_cfg.get("k1", 1.0))
+        k2 = float(self.idx_cfg.get("k2_eur_kwh", 0.0))
+        losses = float(self.idx_cfg.get("losses_pct", 0.0))
+        rates_cfg = self.idx_cfg.get("tariff_energy_eur_kwh", {})
+
+        periods: List[str] = []
+        omie_adjusted: List[float] = []
+        k2_list: List[float] = []
+        tariffs: List[float] = []
+        electricity_base: List[float] = []
+
+        for ts, row in df.iterrows():
+            period = get_tariff_period(ts, option, cycle)
+            periods.append(period)
+
+            omie_price = float(row.get("price_omie_eur_kwh", 0.0))
+            omie_adj = omie_price * (1 + losses) * k1
+            omie_adjusted.append(omie_adj)
+
+            k2_list.append(k2)
+
             tar = 0.0
-        tariffs.append(tar)
-        
-        # Total electricity base (before VAT)
-        energy_base = omie_adj + k2 + tar
-        electricity_base.append(energy_base)
+            if option == "simples":
+                tar = float(rates_cfg.get("simples", 0.0))
+            elif option == "bi":
+                tar = float(rates_cfg.get("bi", {}).get(period, 0.0))
+            elif option == "tri":
+                tar = float(rates_cfg.get("tri", {}).get(period, 0.0))
+            tariffs.append(tar)
 
-    # Add columns to dataframe
-    prices_df['tariff_period'] = periods
-    prices_df['price_omie_adjusted_eur_kwh'] = omie_adjusted
-    prices_df['k2_eur_kwh'] = k2_list
-    prices_df['tariff_energy_eur_kwh'] = tariffs
-    prices_df['price_electricity_base_eur_kwh'] = electricity_base
-    
-    # Keep final price for backward compatibility (includes everything with VAT)
-    # This will be recalculated properly in billing engine
-    prices_df['price_final_eur_kwh'] = prices_df['price_electricity_base_eur_kwh']
-    
-    return prices_df
+            electricity_base.append(omie_adj + k2 + tar)
+
+        df["tariff_period"] = periods
+        df["price_omie_adjusted_eur_kwh"] = pd.Series(omie_adjusted, index=df.index)
+        df["k2_eur_kwh"] = pd.Series(k2_list, index=df.index)
+        df["tariff_energy_eur_kwh"] = pd.Series(tariffs, index=df.index)
+        df["price_electricity_base_eur_kwh"] = pd.Series(
+            electricity_base, index=df.index
+        )
+        df["price_final_eur_kwh"] = df["price_electricity_base_eur_kwh"]
+
+        return df
+
+    def compute_daily_fixed_costs(
+        self, contracted_power_kva: float
+    ) -> Tuple[Dict[str, float], Dict[str, float]]:
+        k3_daily = float(self.idx_cfg.get("k3_eur_day", 0.0))
+        power_base = float(self.idx_cfg.get("tariff_power_eur_kva_day", 0.0)) * contracted_power_kva
+
+        threshold = float(self.config.get("fixed_power_reduced_vat_threshold_kva", 6.9))
+        reduced_rate = float(self.config.get("fixed_power_reduced_vat_rate", 0.06))
+        standard_rate = float(self.config.get("fixed_power_vat_rate", 0.23))
+
+        if contracted_power_kva <= threshold:
+            vat_rate = reduced_rate
+            vat_type = "reduced"
+        else:
+            vat_rate = standard_rate
+            vat_type = "standard"
+
+        power_daily = power_base * (1 + vat_rate)
+
+        terms = {
+            "k3_daily": k3_daily,
+            "power_daily": power_daily,
+        }
+
+        metadata = {
+            "power_vat_rate": vat_rate,
+            "vat_type": vat_type,
+            "threshold_kva": threshold,
+            "contracted_power_kva": contracted_power_kva,
+        }
+
+        if "k3_eur_day" in self.idx_cfg:
+            metadata["k3_source"] = "configured"
+
+        return terms, metadata
+
+    def summary_lines(self) -> List[str]:
+        lines = []
+        option = self.idx_cfg.get("option", "simples")
+        cycle = self.idx_cfg.get("cycle", "daily")
+        lines.append(f"Option: {option}")
+        lines.append(f"Cycle: {cycle}")
+
+        lines.append(
+            f"Indexed modifiers -> k1: {self.idx_cfg.get('k1', 1.0)}, "
+            f"k2: €{self.idx_cfg.get('k2_eur_kwh', 0.0):.4f}/kWh, "
+            f"losses: {self.idx_cfg.get('losses_pct', 0.0) * 100:.2f}%"
+        )
+
+        rates_cfg = self.idx_cfg.get("tariff_energy_eur_kwh", {})
+        if option == "simples":
+            if "simples" in rates_cfg:
+                lines.append(
+                    f"Energy add-on (simples): €{rates_cfg['simples']:.4f}/kWh"
+                )
+        elif option == "bi":
+            bi_rates = rates_cfg.get("bi", {})
+            if bi_rates:
+                lines.append("Energy add-on (bi-horária):")
+                for period_key, label in (
+                    ("fora_vazio", "Fora de vazio"),
+                    ("vazio", "Vazio"),
+                ):
+                    if period_key in bi_rates:
+                        lines.append(
+                            f"  {label}: €{bi_rates[period_key]:.4f}/kWh"
+                        )
+        elif option == "tri":
+            tri_rates = rates_cfg.get("tri", {})
+            if tri_rates:
+                lines.append("Energy add-on (tri-horária):")
+                for period_key in ("ponta", "cheias", "vazio"):
+                    if period_key in tri_rates:
+                        lines.append(
+                            f"  {period_key.capitalize()}: €{tri_rates[period_key]:.4f}/kWh"
+                        )
+
+        power_term = float(
+            self.idx_cfg.get("tariff_power_eur_kva_day", 0.0)
+        )
+        lines.append(
+            f"Power term base: €{power_term:.4f}/kVA/day (VAT applied later)"
+        )
+
+        return lines
+
+
+class SimpleTariffProcessor(TariffProcessor):
+    """Processor for simple (flat) tariffs with pre-defined prices."""
+
+    def __init__(self, tariff_cfg: Dict):
+        super().__init__(tariff_cfg)
+        section = None
+        for key in ("simples", "simple"):
+            if key in tariff_cfg:
+                section = tariff_cfg[key]
+                break
+        if section is None:
+            raise ValueError("Simple tariff requires 'simples' section")
+        self.simple_cfg = section
+
+    def _get_energy_price(self) -> float:
+        price_cfg = self.simple_cfg.get("price_electricity_eur_kwh")
+        if isinstance(price_cfg, dict):
+            price = price_cfg.get("simples")
+        else:
+            price = price_cfg
+        if price is None:
+            raise ValueError("Simple tariff missing 'price_electricity_eur_kwh'")
+        return float(price)
+
+    def _get_power_term_daily(self) -> float:
+        for key in (
+            "power_term_daily_eur",
+            "fixed_power_term_daily_eur",
+            "power_term_eur_day",
+            "tariff_power_eur_day",
+        ):
+            if key in self.simple_cfg:
+                return float(self.simple_cfg[key])
+        raise ValueError("Simple tariff missing daily power term value")
+
+    def apply(self, prices_df: pd.DataFrame) -> pd.DataFrame:
+        df = prices_df.copy()
+        base_price = self._get_energy_price()
+
+        df["tariff_period"] = "simples"
+        df["price_omie_adjusted_eur_kwh"] = 0.0
+        df["k2_eur_kwh"] = 0.0
+        df["tariff_energy_eur_kwh"] = base_price
+        df["price_electricity_base_eur_kwh"] = base_price
+        df["price_final_eur_kwh"] = base_price
+        df["price_omie_eur_kwh"] = base_price
+
+        return df
+
+    def compute_daily_fixed_costs(
+        self, contracted_power_kva: float
+    ) -> Tuple[Dict[str, float], Dict[str, float]]:
+        k3_daily = float(self.simple_cfg.get("k3_eur_day", 0.0))
+        power_daily = self._get_power_term_daily()
+        terms = {
+            "k3_daily": k3_daily,
+            "power_daily": power_daily,
+        }
+        metadata = {
+            "power_term_source": "provided_final",
+            "k3_source": "configured" if "k3_eur_day" in self.simple_cfg else "absent",
+        }
+        return terms, metadata
+
+    def summary_lines(self) -> List[str]:
+        lines = [
+            f"Energy price (flat): €{self._get_energy_price():.4f}/kWh",
+            f"Power term (daily, provided): €{self._get_power_term_daily():.4f}",
+        ]
+        if "k3_eur_day" in self.simple_cfg:
+            lines.append(f"K3 daily (provided): €{self.simple_cfg['k3_eur_day']:.4f}")
+        return lines
+
+
+class BiHourlyTariffProcessor(TariffProcessor):
+    """Processor for bi-horária tariffs with pre-defined period prices."""
+
+    def __init__(self, tariff_cfg: Dict):
+        super().__init__(tariff_cfg)
+        section = None
+        for key in ("bi_horaria", "bi-horaria", "bi"):  # accept common variants
+            if key in tariff_cfg:
+                section = tariff_cfg[key]
+                break
+        if section is None:
+            raise ValueError("Bi-horária tariff requires 'bi_horaria' section")
+        self.bi_cfg = section
+
+    def _get_rates(self) -> Dict[str, float]:
+        rates = self.bi_cfg.get("price_electricity_eur_kwh", {})
+        if "bi" in rates and isinstance(rates["bi"], dict):
+            rates = rates["bi"]
+        if not rates:
+            raise ValueError("Bi-horária tariff missing energy price mapping")
+        return {k: float(v) for k, v in rates.items()}
+
+    def _get_power_term_daily(self) -> float:
+        for key in (
+            "power_term_daily_eur",
+            "fixed_power_term_daily_eur",
+            "power_term_eur_day",
+            "tariff_power_eur_day",
+        ):
+            if key in self.bi_cfg:
+                return float(self.bi_cfg[key])
+        raise ValueError("Bi-horária tariff missing daily power term value")
+
+    def apply(self, prices_df: pd.DataFrame) -> pd.DataFrame:
+        df = prices_df.copy()
+        option = self.bi_cfg.get("option", "bi")
+        cycle = self.bi_cfg.get("cycle", "daily")
+        rates = self._get_rates()
+
+        periods: List[str] = []
+        base_prices: List[float] = []
+
+        default_fora_vazio = rates.get("fora_vazio")
+
+        for ts in df.index:
+            period = get_tariff_period(ts, option, cycle)
+            price = rates.get(period)
+
+            if price is None:
+                # Fallback to fora_vazio for any undefined non-vazio period
+                if period != "vazio" and default_fora_vazio is not None:
+                    price = default_fora_vazio
+                elif "default" in rates:
+                    price = rates["default"]
+            if price is None:
+                raise ValueError(
+                    f"No price configured for period '{period}' in bi-horária tariff"
+                )
+
+            periods.append(period)
+            base_prices.append(float(price))
+
+        base_series = pd.Series(base_prices, index=df.index)
+        df["tariff_period"] = periods
+        df["price_omie_adjusted_eur_kwh"] = 0.0
+        df["k2_eur_kwh"] = 0.0
+        df["tariff_energy_eur_kwh"] = base_series
+        df["price_electricity_base_eur_kwh"] = base_series
+        df["price_final_eur_kwh"] = base_series
+        df["price_omie_eur_kwh"] = base_series
+
+        return df
+
+    def compute_daily_fixed_costs(
+        self, contracted_power_kva: float
+    ) -> Tuple[Dict[str, float], Dict[str, float]]:
+        k3_daily = float(self.bi_cfg.get("k3_eur_day", 0.0))
+        power_daily = self._get_power_term_daily()
+        terms = {
+            "k3_daily": k3_daily,
+            "power_daily": power_daily,
+        }
+        metadata = {
+            "power_term_source": "provided_final",
+            "k3_source": "configured" if "k3_eur_day" in self.bi_cfg else "absent",
+        }
+        return terms, metadata
+
+    def summary_lines(self) -> List[str]:
+        rates = self._get_rates()
+        lines = [f"Cycle: {self.bi_cfg.get('cycle', 'daily')}"]
+        lines.append("Energy price (bi-horária):")
+        for period_key, label in (
+            ("fora_vazio", "Fora de vazio"),
+            ("vazio", "Vazio"),
+        ):
+            if period_key in rates:
+                lines.append(f"  {label}: €{rates[period_key]:.4f}/kWh")
+        for extra in sorted(set(rates.keys()) - {"fora_vazio", "vazio"}):
+            lines.append(f"  {extra}: €{rates[extra]:.4f}/kWh")
+
+        lines.append(
+            f"Power term (daily, provided): €{self._get_power_term_daily():.4f}"
+        )
+        if "k3_eur_day" in self.bi_cfg:
+            lines.append(f"K3 daily (provided): €{self.bi_cfg['k3_eur_day']:.4f}")
+        return lines
+
+
+def create_tariff_processor(tariff_cfg: Dict) -> TariffProcessor:
+    """Factory returning the appropriate processor for the given tariff type."""
+
+    tariff_type = tariff_cfg.get("type", "indexed").lower()
+
+    if tariff_type == "indexed":
+        return IndexedTariffProcessor(tariff_cfg)
+    if tariff_type in {"simples", "simple"}:
+        return SimpleTariffProcessor(tariff_cfg)
+    if tariff_type in {"bi_horaria", "bi-horaria", "bi"}:
+        return BiHourlyTariffProcessor(tariff_cfg)
+
+    raise ValueError(f"Unsupported tariff type: {tariff_type}")
+
+
+def apply_tariff(prices_df: pd.DataFrame, tariff_cfg: Dict) -> pd.DataFrame:
+    """Convenience wrapper that applies the configured tariff to a dataframe."""
+
+    processor = create_tariff_processor(tariff_cfg)
+    return processor.apply(prices_df)
+
+
+def apply_indexed_tariff(prices_df: pd.DataFrame, tariff_cfg: dict) -> pd.DataFrame:
+    """Backward compatible helper kept for existing imports."""
+
+    processor = IndexedTariffProcessor(tariff_cfg)
+    return processor.apply(prices_df)

--- a/run_sim.py
+++ b/run_sim.py
@@ -25,6 +25,7 @@ from ess.io import prepare_simulation_data, save_results
 from ess.strategies import ArbitrageStrategy, OptimalArbitrageStrategy
 from ess.simulator import EnergyArbitrageSimulator
 from ess.billing import BillingEngine
+from ess.tariff import create_tariff_processor
 
 
 def load_config(config_path: str = "configs/scenario.yaml") -> dict:
@@ -40,89 +41,99 @@ def create_output_dirs(config: dict):
         Path(config['output']['plots_dir']).mkdir(parents=True, exist_ok=True)
 
 
-def calculate_daily_fixed_costs(config: dict) -> dict:
-    """Calculate daily fixed costs with proper VAT application."""
+def calculate_daily_fixed_costs(
+    config: dict, tariff_processor=None
+) -> dict:
+    """Calculate daily fixed costs using the configured tariff processor."""
+
     tcfg = config['tariff']
-    idx_cfg = tcfg['indexed']
     contracted_power_kva = config['power_contract']['contracted_power_kva']
-    
-    # Fixed costs breakdown
-    costs = {}
-    
-    # K3 term (always standard VAT)
-    costs['k3_daily'] = idx_cfg['k3_eur_day']
-    
-    # Power term with conditional VAT
-    power_cost_base = idx_cfg['tariff_power_eur_kva_day'] * contracted_power_kva
-    
-    # Check if contracted power qualifies for reduced VAT on fixed power term
-    power_threshold = tcfg.get('fixed_power_reduced_vat_threshold_kva', 6.9)
-    if contracted_power_kva <= power_threshold:
-        power_vat_rate = tcfg.get('fixed_power_reduced_vat_rate', 0.06)
-        print(f"✓ Using reduced VAT ({power_vat_rate:.0%}) for power term (contracted power: {contracted_power_kva} kVA <= {power_threshold} kVA)")
-    else:
-        power_vat_rate = tcfg.get('fixed_power_vat_rate', 0.23)
-        print(f"✓ Using standard VAT ({power_vat_rate:.0%}) for power term (contracted power: {contracted_power_kva} kVA > {power_threshold} kVA)")
-    
-    costs['power_daily'] = power_cost_base * (1 + power_vat_rate)
-    
+    processor = tariff_processor or create_tariff_processor(tcfg)
+
+    fixed_terms, metadata = processor.compute_daily_fixed_costs(contracted_power_kva)
+
+    costs = {
+        'k3_daily': float(fixed_terms.get('k3_daily', 0.0)),
+        'power_daily': float(fixed_terms.get('power_daily', 0.0)),
+    }
+
+    metadata = metadata or {}
+
+    if 'power_vat_rate' in metadata:
+        vat_rate = metadata['power_vat_rate']
+        vat_type = metadata.get('vat_type', 'standard')
+        threshold = metadata.get('threshold_kva')
+        contracted = metadata.get('contracted_power_kva', contracted_power_kva)
+        if vat_type == 'reduced':
+            print(
+                f"✓ Using reduced VAT ({vat_rate:.0%}) for power term (contracted power: {contracted} kVA <= {threshold} kVA)"
+            )
+        else:
+            print(
+                f"✓ Using standard VAT ({vat_rate:.0%}) for power term (contracted power: {contracted} kVA > {threshold} kVA)"
+            )
+    elif metadata.get('power_term_source'):
+        source = metadata['power_term_source'].replace('_', ' ')
+        print(
+            f"✓ Using provided power term ({source}) -> €{costs['power_daily']:.4f}/day"
+        )
+
+    if metadata.get('k3_source') == 'configured' and costs['k3_daily']:
+        print(f"✓ Using provided K3 daily cost -> €{costs['k3_daily']:.4f}/day")
+
     # CAV fee (monthly converted to daily)
-    cav_daily = tcfg['cav_fee_eur_month'] / 30 * (1 + tcfg['cav_vat_rate'])
-    costs['cav_daily'] = cav_daily
-    
-    # DGEG fee (monthly converted to daily)  
-    dgeg_daily = tcfg['dgeg_fee_eur_month'] / 30 * (1 + tcfg['dgeg_vat_rate'])
-    costs['dgeg_daily'] = dgeg_daily
-    
-    # Total daily fixed cost
-    total_daily_fixed = (
-        costs['k3_daily'] + 
-        costs['power_daily'] + 
-        costs['cav_daily'] + 
-        costs['dgeg_daily']
+    costs['cav_daily'] = tcfg['cav_fee_eur_month'] / 30 * (1 + tcfg['cav_vat_rate'])
+
+    # DGEG fee (monthly converted to daily)
+    costs['dgeg_daily'] = tcfg['dgeg_fee_eur_month'] / 30 * (1 + tcfg['dgeg_vat_rate'])
+
+    costs['total_daily'] = (
+        costs['k3_daily']
+        + costs['power_daily']
+        + costs['cav_daily']
+        + costs['dgeg_daily']
     )
-    costs['total_daily'] = total_daily_fixed
-    
+
     return costs
 
 
-def print_tariff_summary(config: dict, fixed_costs: dict):
+def print_tariff_summary(config: dict, fixed_costs: dict, tariff_processor=None):
     """Print a summary of the tariff configuration."""
-    print("\n" + "="*50)
+
+    print("\n" + "=" * 50)
     print("TARIFF CONFIGURATION SUMMARY")
-    print("="*50)
-    
+    print("=" * 50)
+
     tcfg = config['tariff']
-    idx_cfg = tcfg['indexed']
     contracted_power = config['power_contract']['contracted_power_kva']
-    
+    processor = tariff_processor or create_tariff_processor(tcfg)
+
     print(f"Tariff type: {tcfg['type']}")
-    print(f"Option: {idx_cfg['option']}")
-    print(f"Cycle: {idx_cfg['cycle']}")
     print(f"Contracted power: {contracted_power} kVA")
-    
-    print(f"\nEnergy VAT rates:")
+
+    details = processor.summary_lines()
+    if details:
+        print("\nTariff details:")
+        for line in details:
+            print(f"  {line}")
+
+    print("\nEnergy VAT rates:")
     print(f"  Standard VAT: {tcfg['vat_rate']:.0%}")
     print(f"  Reduced VAT: {tcfg['reduced_vat_rate']:.0%}")
-    print(f"  Reduced VAT threshold: {tcfg.get('fixed_power_reduced_vat_threshold_kva', 6.9)} kVA")
-    print(f"  Reduced VAT allowance: {tcfg['reduced_vat_kwh_per_30_days']} kWh per {tcfg['vat_cycle_days']} days")
-    
-    print(f"\nFixed power term VAT rates:")
-    power_threshold = tcfg.get('fixed_power_reduced_vat_threshold_kva', 6.9)
-    if contracted_power <= power_threshold:
-        rate_used = tcfg.get('fixed_power_reduced_vat_rate', 0.06)
-        print(f"  Applied VAT: {rate_used:.0%} (reduced - power <= {power_threshold} kVA)")
-    else:
-        rate_used = tcfg.get('fixed_power_vat_rate', 0.23)
-        print(f"  Applied VAT: {rate_used:.0%} (standard - power > {power_threshold} kVA)")
-    
-    print(f"\nDaily fixed costs:")
+    print(
+        f"  Reduced VAT threshold: {tcfg.get('fixed_power_reduced_vat_threshold_kva', 6.9)} kVA"
+    )
+    print(
+        f"  Reduced VAT allowance: {tcfg['reduced_vat_kwh_per_30_days']} kWh per {tcfg['vat_cycle_days']} days"
+    )
+
+    print("\nDaily fixed costs:")
     print(f"  K3 term: €{fixed_costs['k3_daily']:.4f}")
-    print(f"  Power term (with VAT): €{fixed_costs['power_daily']:.4f}")
+    print(f"  Power term: €{fixed_costs['power_daily']:.4f}")
     print(f"  CAV fee: €{fixed_costs['cav_daily']:.4f}")
     print(f"  DGEG fee: €{fixed_costs['dgeg_daily']:.4f}")
     print(f"  Total daily fixed: €{fixed_costs['total_daily']:.4f}")
-    print("="*50)
+    print("=" * 50)
 
 
 def run_billing(results_df, prices_df, config, fixed_costs):
@@ -628,9 +639,10 @@ def main():
     # Load configuration
     config = load_config()
     create_output_dirs(config)
-    
-    # Calculate fixed costs with proper VAT
-    fixed_costs = calculate_daily_fixed_costs(config)
+
+    # Instantiate tariff processor and fixed costs
+    tariff_processor = create_tariff_processor(config['tariff'])
+    fixed_costs = calculate_daily_fixed_costs(config, tariff_processor)
     
     # Parse dates
     start_date = datetime.strptime(config['period']['start_date'], "%Y-%m-%d")
@@ -651,7 +663,7 @@ def main():
         print(f"Real consumption file: {real_file}")
     
     # Print tariff summary
-    print_tariff_summary(config, fixed_costs)
+    print_tariff_summary(config, fixed_costs, tariff_processor)
     
     # Load and prepare data
     print("\nPreparing simulation data...")
@@ -681,11 +693,7 @@ def main():
         prices_df = prices_df.rename(columns={'price_eur_per_kwh': 'price_omie_eur_kwh'})
 
     # Apply tariff to compute final prices
-    from ess.tariff import apply_indexed_tariff
-    if config['tariff']['type'] == 'indexed':
-        prices_df = apply_indexed_tariff(prices_df, config['tariff'])
-    else:
-        raise NotImplementedError("Only indexed tariff is implemented for now")
+    prices_df = tariff_processor.apply(prices_df)
 
     # Create battery
     battery = Battery(


### PR DESCRIPTION
## Summary
- add a TariffProcessor hierarchy covering indexed, simple, and bi-horária tariffs, including energy price application and fixed-cost helpers
- expose a tariff factory and convenience helpers to apply tariffs across the pipeline
- update the simulation entry point to use the new processor for fixed-cost calculations, tariff summaries, and price generation

## Testing
- python run_sim.py

------
https://chatgpt.com/codex/tasks/task_e_68cfe6fbc9608322a029a98796895c2d