### PR TITLE
Adjust TAR potência VAT handling

### DIFF
--- a/configs/scenario.yaml
+++ b/configs/scenario.yaml
@@ -25,7 +25,7 @@ tariff:
   indexed:
     k1: 1.2528
     k2_eur_kwh: 0.0185
-    k3_eur_day: 0.1171 
+    k3_eur_day: 0.1171
 
     losses_pct: 0
     option: "simples"           # simples, bi or tri
@@ -39,11 +39,7 @@ tariff:
         ponta: 0.2469
         cheias: 0.0388
         vazio: 0.0149
-
-    power_term_daily_eur: 0.1587  # = 0.0460 × 4.6 kVA (fixed daily base, excl. VAT)
-    
-    
-  simples:  
+  simples:
     # Flat energy price (€/kWh)
     price_electricity_eur_kwh: 0.1340
     # Power term base (without VAT) — fixed dccaily:
@@ -78,6 +74,19 @@ tariff:
 
   dgeg_fee_eur_month: 0.07  # DGEG fixed monthly fee
   dgeg_vat_rate: 0.23
+
+  # Tarifa de Acesso às Redes — potência (€/dia) por escalão de potência contratada
+  tariff_access_power_daily_eur:
+    1.15: 0.0529
+    2.3: 0.1058
+    3.45: 0.1587
+    4.6: 0.2116
+    5.75: 0.2645
+    6.9: 0.3174
+    10.35: 0.4761
+    13.8: 0.6348
+    17.25: 0.7935
+    20.7: 0.9522
 
 # Contracted power
 power_contract:

--- a/ess/tariff.py
+++ b/ess/tariff.py
@@ -1,7 +1,7 @@
 """Tariff helpers and processors used across the project."""
 
 from datetime import datetime
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import pandas as pd
 import os
@@ -109,6 +109,66 @@ class TariffProcessor:
 
     def __init__(self, tariff_cfg: Dict):
         self.config = tariff_cfg
+        self._tariff_power_table_cache: Optional[Dict[float, float]] = None
+
+    # --- Shared helpers -------------------------------------------------
+
+    def _load_tariff_power_table(self) -> Dict[float, float]:
+        """Return TAR Potência daily values indexed by contracted power."""
+
+        if self._tariff_power_table_cache is None:
+            table_cfg = self.config.get("tariff_access_power_daily_eur")
+            if not table_cfg:
+                raise ValueError(
+                    "Tariff configuration missing 'tariff_access_power_daily_eur' mapping"
+                )
+
+            table: Dict[float, float] = {}
+            for raw_key, raw_value in table_cfg.items():
+                try:
+                    key = float(str(raw_key).replace(",", "."))
+                except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+                    raise ValueError(
+                        f"Invalid power key '{raw_key}' in tariff_access_power_daily_eur"
+                    ) from exc
+
+                try:
+                    value = float(raw_value)
+                except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+                    raise ValueError(
+                        f"Invalid TAR potência value '{raw_value}' for key {raw_key}"
+                    ) from exc
+
+                table[key] = value
+
+            self._tariff_power_table_cache = table
+
+        return self._tariff_power_table_cache
+
+    def _get_tariff_power_daily(self, contracted_power_kva: float) -> float:
+        """Fetch TAR Potência (€/day) for the contracted power."""
+
+        table = self._load_tariff_power_table()
+
+        # Direct match first
+        if contracted_power_kva in table:
+            return table[contracted_power_kva]
+
+        # Fallback: match by rounding to 2 decimals (typical precision in configs)
+        target = round(contracted_power_kva, 2)
+        for power_key, value in table.items():
+            if round(power_key, 2) == target:
+                return value
+
+        # Ultimate fallback: find closest entry within a tiny tolerance
+        closest_power = min(table.keys(), key=lambda pk: abs(pk - contracted_power_kva))
+        if abs(closest_power - contracted_power_kva) <= 1e-3:
+            return table[closest_power]
+
+        raise ValueError(
+            "No TAR potência value configured for contracted power "
+            f"{contracted_power_kva} kVA"
+        )
 
     def apply(self, prices_df: pd.DataFrame) -> pd.DataFrame:
         """Return a dataframe with all mandatory tariff columns populated."""
@@ -188,20 +248,9 @@ class IndexedTariffProcessor(TariffProcessor):
     ) -> Tuple[Dict[str, float], Dict[str, float]]:
         k3_daily = float(self.idx_cfg.get("k3_eur_day", 0.0))
 
-        # --- FIXED DAILY POWER TERM (no per‑kVA scaling) ---
-        if "power_term_daily_eur" in self.idx_cfg:
-            power_base = float(self.idx_cfg["power_term_daily_eur"])  # base excl. VAT
-            base_source = "daily_fixed"
-        elif "tariff_power_eur_day" in self.idx_cfg:
-            power_base = float(self.idx_cfg["tariff_power_eur_day"])  # alias; excl. VAT
-            base_source = "daily_fixed_alias"
-        elif "tariff_power_eur_kva_day" in self.idx_cfg:
-            # Legacy: keep backward compatibility by computing a fixed base at current contracted power
-            power_base = float(self.idx_cfg["tariff_power_eur_kva_day"]) * contracted_power_kva
-            base_source = "legacy_per_kva_scaled_once"
-        else:
-            power_base = 0.0
-            base_source = "absent"
+        # --- FIXED DAILY POWER TERM (Tarifa de acesso potência) ---
+        power_base = self._get_tariff_power_daily(contracted_power_kva)
+        base_source = "tariff_power_table"
 
         threshold = float(self.config.get("fixed_power_reduced_vat_threshold_kva", 6.9))
         reduced_rate = float(self.config.get("fixed_power_reduced_vat_rate", 0.06))
@@ -230,6 +279,8 @@ class IndexedTariffProcessor(TariffProcessor):
             "threshold_kva": threshold,
             "contracted_power_kva": contracted_power_kva,
             "power_term_source": base_source,
+            "tariff_power_component_daily_eur": power_base,
+            "tariff_power_component_vat_rate": vat_rate,
         }
 
         if "k3_eur_day" in self.idx_cfg:
@@ -278,9 +329,14 @@ class IndexedTariffProcessor(TariffProcessor):
                             f"  {period_key.capitalize()}: €{tri_rates[period_key]:.4f}/kWh"
                         )
 
-        lines.append(
-            f"Power term base (daily, excl. VAT): €{float(self.idx_cfg.get('power_term_daily_eur', self.idx_cfg.get('tariff_power_eur_day', self.idx_cfg.get('tariff_power_eur_kva_day', 0.0)))):.4f}"
-        )
+        if self.config.get("tariff_access_power_daily_eur"):
+            available_powers = ", ".join(
+                f"{power:g} kVA" for power in sorted(self._load_tariff_power_table().keys())
+            )
+            lines.append(
+                "Power term base (daily, excl. VAT): TAR potência from table"
+            )
+            lines.append(f"  Available contracted powers: {available_powers}")
 
         return lines
 
@@ -339,20 +395,27 @@ class SimpleTariffProcessor(TariffProcessor):
         # --- FIXED DAILY POWER TERM (no per‑kVA scaling) ---
         power_base = self._get_power_term_daily()  # base excl. VAT
         base_source = "daily_fixed"
+        tar_power_base = self._get_tariff_power_daily(contracted_power_kva)
 
         # VAT threshold logic (same as IndexedTariffProcessor)
         threshold = float(self.config.get("fixed_power_reduced_vat_threshold_kva", 6.9))
         reduced_rate = float(self.config.get("fixed_power_reduced_vat_rate", 0.06))
         standard_rate = float(self.config.get("fixed_power_vat_rate", 0.23))
 
-        if contracted_power_kva <= threshold:
-            vat_rate = reduced_rate
-            vat_type = "reduced"
-        else:
-            vat_rate = standard_rate
-            vat_type = "standard"
+        # Start with all components taxed at the standard rate
+        power_daily = power_base * (1 + standard_rate)
+        vat_type = "standard"
+        applied_tariff_vat_rate = standard_rate
 
-        power_daily = power_base * (1 + vat_rate)
+        if contracted_power_kva <= threshold:
+            # Replace VAT on TAR Potência component with the reduced rate
+            power_daily = (
+                power_daily
+                - tar_power_base * (1 + standard_rate)
+                + tar_power_base * (1 + reduced_rate)
+            )
+            vat_type = "tariff_only_reduced"
+            applied_tariff_vat_rate = reduced_rate
 
         terms = {
             "k3_daily": k3_daily,
@@ -360,12 +423,14 @@ class SimpleTariffProcessor(TariffProcessor):
         }
 
         metadata = {
-            "power_vat_rate": vat_rate,
+            "power_vat_rate": applied_tariff_vat_rate,
             "vat_type": vat_type,
             "threshold_kva": threshold,
             "contracted_power_kva": contracted_power_kva,
             "power_term_source": base_source,
             "k3_source": "absent",
+            "tariff_power_component_daily_eur": tar_power_base,
+            "tariff_power_component_vat_rate": applied_tariff_vat_rate,
         }
 
         return terms, metadata
@@ -459,32 +524,39 @@ class BiHourlyTariffProcessor(TariffProcessor):
         # --- FIXED DAILY POWER TERM (no per‑kVA scaling) ---
         power_base = self._get_power_term_daily()  # base excl. VAT
         base_source = "daily_fixed"
+        tar_power_base = self._get_tariff_power_daily(contracted_power_kva)
 
         # VAT threshold logic (same as IndexedTariffProcessor)
         threshold = float(self.config.get("fixed_power_reduced_vat_threshold_kva", 6.9))
         reduced_rate = float(self.config.get("fixed_power_reduced_vat_rate", 0.06))
         standard_rate = float(self.config.get("fixed_power_vat_rate", 0.23))
 
-        if contracted_power_kva <= threshold:
-            vat_rate = reduced_rate
-            vat_type = "reduced"
-        else:
-            vat_rate = standard_rate
-            vat_type = "standard"
+        power_daily = power_base * (1 + standard_rate)
+        vat_type = "standard"
+        applied_tariff_vat_rate = standard_rate
 
-        power_daily = power_base * (1 + vat_rate)
+        if contracted_power_kva <= threshold:
+            power_daily = (
+                power_daily
+                - tar_power_base * (1 + standard_rate)
+                + tar_power_base * (1 + reduced_rate)
+            )
+            vat_type = "tariff_only_reduced"
+            applied_tariff_vat_rate = reduced_rate
 
         terms = {
             "k3_daily": k3_daily,
             "power_daily": power_daily,
         }
         metadata = {
-            "power_vat_rate": vat_rate,
+            "power_vat_rate": applied_tariff_vat_rate,
             "vat_type": vat_type,
             "threshold_kva": threshold,
             "contracted_power_kva": contracted_power_kva,
             "power_term_source": base_source,
             "k3_source": "absent",
+            "tariff_power_component_daily_eur": tar_power_base,
+            "tariff_power_component_vat_rate": applied_tariff_vat_rate,
         }
         return terms, metadata
 

--- a/run_sim.py
+++ b/run_sim.py
@@ -64,9 +64,16 @@ def calculate_daily_fixed_costs(
         vat_type = metadata.get('vat_type', 'standard')
         threshold = metadata.get('threshold_kva')
         contracted = metadata.get('contracted_power_kva', contracted_power_kva)
+        standard_vat = tcfg.get('fixed_power_vat_rate', 0.23)
+
         if vat_type == 'reduced':
             print(
                 f"✓ Using reduced VAT ({vat_rate:.0%}) for power term (contracted power: {contracted} kVA <= {threshold} kVA)"
+            )
+        elif vat_type == 'tariff_only_reduced':
+            print(
+                "✓ Applying reduced VAT "
+                f"({vat_rate:.0%}) only to TAR potência component; remaining fixed term taxed at {standard_vat:.0%}"
             )
         else:
             print(


### PR DESCRIPTION
## Summary
- add Tarifa de Acesso às Redes potencia daily lookup table to the scenario configuration
- update tariff processors to derive TAR potência amounts from the shared table and apply reduced VAT only to the TAR component when eligible
- enhance run_sim fixed-cost summary messaging to describe the partial VAT reduction scenario

## Testing
- python -m compileall ess run_sim.py

------
https://chatgpt.com/codex/tasks/task_e_68d437201770832284cae20a835c8078